### PR TITLE
Force to fail gtg check

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -125,7 +125,7 @@ func (c Controller) handleHealthcheck(w http.ResponseWriter, r *http.Request) {
 func (c Controller) handleGoodToGo(w http.ResponseWriter, r *http.Request) {
 	categories := parseCategories(r.URL)
 	healthResults, validCategories := c.buildHealthResultFor(categories, useCache(r.URL))
-	// check any any of the categories are disabled
+	// check if any of the categories are disabled
 	enabled := c.catEnabled(validCategories)
 	if !enabled {
 		w.WriteHeader(http.StatusServiceUnavailable)

--- a/serviceRegistry.go
+++ b/serviceRegistry.go
@@ -189,13 +189,8 @@ func (r *ServiceRegistry) redefineCategoryList() {
 		}
 		name := filepath.Base(categoryNode.Key)
 
-		//Period
 		period := r.catPeriod(categoryNode.Key)
-
-		//Resilient
 		resilient := r.catResilient(categoryNode.Key)
-
-		//Enabled
 		enabled := r.catEnabled(categoryNode.Key)
 
 		categories[name] = Category{Name: name, Period: period, IsResilient: resilient, Enabled: enabled}
@@ -209,14 +204,14 @@ func (r *ServiceRegistry) catPeriod(catKey string) (period time.Duration) {
 	periodResp, err := r.etcd.Get(context.Background(), catKey+periodKeySuffix, &client.GetOptions{Sort: true})
 	if err != nil {
 		warnLogger.Printf("Failed to get health check period from %v: %v. Using default %v", catKey, err.Error(), defaultDuration)
-	} else {
-		periodInt, err := strconv.Atoi(periodResp.Node.Value)
-		if err != nil {
-			warnLogger.Printf("Error reading health check period value '%v'. Using default %v", periodResp.Node.Value, defaultDuration)
-			periodInt = int(defaultDuration.Seconds())
-		}
-		period = time.Duration(periodInt) * time.Second
+		return
 	}
+	periodInt, err := strconv.Atoi(periodResp.Node.Value)
+	if err != nil {
+		warnLogger.Printf("Error reading health check period value '%v'. Using default %v", periodResp.Node.Value, defaultDuration)
+		return
+	}
+	period = time.Duration(periodInt) * time.Second
 	return
 }
 
@@ -225,11 +220,11 @@ func (r *ServiceRegistry) catResilient(catKey string) (resilient bool) {
 	resilientResp, err := r.etcd.Get(context.Background(), catKey+resilientSuffix, nil)
 	if err != nil {
 		warnLogger.Printf("Failed to get resilient setting from %v: %v. Using default: %v.\n", catKey, err.Error(), resilient)
-	} else {
-		resilient, err = strconv.ParseBool(resilientResp.Node.Value)
-		if err != nil {
-			warnLogger.Printf("Error reading resilient setting '%v' at key %v. Using default: %v.", resilientResp.Node.Value, resilientResp.Node.Key, resilient)
-		}
+		return
+	}
+	resilient, err = strconv.ParseBool(resilientResp.Node.Value)
+	if err != nil {
+		warnLogger.Printf("Error reading resilient setting '%v' at key %v. Using default: %v.", resilientResp.Node.Value, resilientResp.Node.Key, resilient)
 	}
 	return
 }
@@ -239,11 +234,11 @@ func (r *ServiceRegistry) catEnabled(catKey string) (enabled bool) {
 	enabledResp, err := r.etcd.Get(context.Background(), catKey+enabledSuffix, nil)
 	if err != nil {
 		warnLogger.Printf("Failed to get enabled setting from %v: %v. Using default: %v.\n", catKey, err.Error(), enabled)
-	} else {
-		enabled, err = strconv.ParseBool(enabledResp.Node.Value)
-		if err != nil {
-			warnLogger.Printf("Error reading resilient setting '%v' at key %v. Using default: %v.", enabledResp.Node.Value, enabledResp.Node.Key, enabled)
-		}
+		return
+	}
+	enabled, err = strconv.ParseBool(enabledResp.Node.Value)
+	if err != nil {
+		warnLogger.Printf("Error reading resilient setting '%v' at key %v. Using default: %v.", enabledResp.Node.Value, enabledResp.Node.Key, enabled)
 	}
 	return
 }


### PR DESCRIPTION
To be used for os upgrades, fails over DNS
example: 
```
core@ip-172-24-121-215 ~ $ etcdctl set /ft/healthcheck-categories/read/enabled false
false

INFO  - 2016/04/14 18:44:14.329321 serviceRegistry.go:174: Reloading category list.
WARN  - 2016/04/14 18:44:14.486753 serviceRegistry.go:241: Failed to get enabled setting from /ft/healthcheck-categories/system: 100: Key not found (/ft/healthcheck-categories/system/enabled) [372158027]. Using default: true.
INFO  - 2016/04/14 18:44:14.486817 serviceRegistry.go:204: Categories: [
        Category: [default]. Period: [1m0s]. Resilient: [false]. Enabled: [true]
        Category: [read]. Period: [4s]. Resilient: [true]. Enabled: [false]
        Category: [system]. Period: [1m0s]. Resilient: [false]. Enabled: [true]
]

~/curl -i http://localhost:8080/__gtg?categories=read
HTTP/1.1 503 Service Unavailable
Date: Thu, 14 Apr 2016 18:44:45 GMT
Content-Length: 0
Content-Type: text/plain; charset=utf-8

core@ip-172-24-121-215 ~ $ etcdctl set /ft/healthcheck-categories/read/enabled true
true

INFO  - 2016/04/14 18:44:53.457172 serviceRegistry.go:174: Reloading category list.
WARN  - 2016/04/14 18:44:53.755024 serviceRegistry.go:241: Failed to get enabled setting from /ft/healthcheck-categories/system: 100: Key not found (/ft/healthcheck-categories/system/enabled) [372160660]. Using default: true.
INFO  - 2016/04/14 18:44:53.755125 serviceRegistry.go:204: Categories: [
        Category: [default]. Period: [1m0s]. Resilient: [false]. Enabled: [true]
        Category: [read]. Period: [4s]. Resilient: [true]. Enabled: [true]
        Category: [system]. Period: [1m0s]. Resilient: [false]. Enabled: [true]
]

~/curl -i http://localhost:8080/__gtg?categories=read
HTTP/1.1 200 OK
Date: Thu, 14 Apr 2016 18:46:21 GMT
Content-Length: 0
Content-Type: text/plain; charset=utf-8
```