### PR TITLE
Sticky healthcheck

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -2,12 +2,13 @@ package main
 
 import (
 	"encoding/json"
-	fthealth "github.com/Financial-Times/go-fthealth/v1a"
 	"html/template"
 	"net/http"
 	"net/url"
 	"sort"
 	"strings"
+
+	fthealth "github.com/Financial-Times/go-fthealth/v1a"
 )
 
 const timeLayout = "15:04:05 MST"
@@ -176,6 +177,9 @@ func (c Controller) handleGoodToGo(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if !healthResults.Ok {
+		for _, validCat := range validCategories {
+			c.registry.disableCategoryIfSticky(validCat)
+		}
 		w.WriteHeader(http.StatusServiceUnavailable)
 	}
 }

--- a/serviceRegistry.go
+++ b/serviceRegistry.go
@@ -237,18 +237,18 @@ func (r *ServiceRegistry) catResilient(catKey string) (resilient bool) {
 
 func (r *ServiceRegistry) disableCategoryIfSticky(cat string) {
 	sticky := false
-	stickyResp, err := r.etcd.Get(context.Background(), categoriesKeyPre+cat+stickySuffix, nil)
+	stickyResp, err := r.etcd.Get(context.Background(), categoriesKeyPre+"/"+cat+stickySuffix, nil)
 	if err != nil {
-		warnLogger.Printf("Failed to get sticky setting from %v: %v.\n", categoriesKeyPre+cat, err.Error())
+		warnLogger.Printf("Failed to get sticky setting from %v: %v.\n", categoriesKeyPre+"/"+cat, err.Error())
 	}
 	sticky, err = strconv.ParseBool(stickyResp.Node.Value)
 	if err != nil {
 		warnLogger.Printf("Error reading sticky setting '%v' at key %v.", stickyResp.Node.Value, stickyResp.Node.Key)
 	}
 	if sticky {
-		_, err = r.etcd.Set(context.Background(), categoriesKeyPre+cat+enabledSuffix, "false", nil)
+		_, err = r.etcd.Set(context.Background(), categoriesKeyPre+"/"+cat+enabledSuffix, "false", nil)
 		if err != nil {
-			warnLogger.Printf("Failed to disable %v: %v.\n", categoriesKeyPre+cat, err.Error())
+			warnLogger.Printf("Failed to disable %v: %v.\n", categoriesKeyPre+"/"+cat, err.Error())
 		}
 		infoLogger.Printf("Setting category enabled %v to false.", cat)
 	}

--- a/serviceRegistry.go
+++ b/serviceRegistry.go
@@ -240,10 +240,12 @@ func (r *ServiceRegistry) disableCategoryIfSticky(cat string) {
 	stickyResp, err := r.etcd.Get(context.Background(), categoriesKeyPre+"/"+cat+stickySuffix, nil)
 	if err != nil {
 		warnLogger.Printf("Failed to get sticky setting from %v: %v.\n", categoriesKeyPre+"/"+cat, err.Error())
+		return
 	}
 	sticky, err = strconv.ParseBool(stickyResp.Node.Value)
 	if err != nil {
 		warnLogger.Printf("Error reading sticky setting '%v' at key %v.", stickyResp.Node.Value, stickyResp.Node.Key)
+		return
 	}
 	if sticky {
 		_, err = r.etcd.Set(context.Background(), categoriesKeyPre+"/"+cat+enabledSuffix, "false", nil)


### PR DESCRIPTION
Allow healthchecks to be made sticky, forcing them to stay failed (By setting etcd enabled) when the gtg returns an error.