### PR TITLE
More pointer receivers.

### DIFF
--- a/eventlimiter.go
+++ b/eventlimiter.go
@@ -9,8 +9,8 @@ type EventLimiter struct {
 	timePassed   chan bool
 }
 
-func NewEventLimiter(f func()) *EventLimiter {
-	ticker := time.NewTicker(60 * time.Second)
+func NewEventLimiter(f func(), interval time.Duration) *EventLimiter {
+	ticker := time.NewTicker(interval)
 	trigger := make(chan bool, 1)
 	wasTriggered := make(chan bool, 1)
 	timePassed := make(chan bool, 1)

--- a/serviceRegistry.go
+++ b/serviceRegistry.go
@@ -78,6 +78,7 @@ type ServiceRegistry interface {
 
 type EtcdServiceRegistry struct {
 	etcd              EtcdHealthCheckKeysAPI
+	etcdInterval      time.Duration
 	vulcandAddr       string
 	_checker          HealthChecker
 	services          servicesMap
@@ -95,27 +96,27 @@ func NewCocoServiceRegistry(etcd EtcdHealthCheckKeysAPI, vulcandAddr string, che
 	services := make(map[string]Service)
 	categories := make(map[string]Category)
 	measuredServices := make(map[string]MeasuredService)
-	return &EtcdServiceRegistry{etcd, vulcandAddr, checker, services, categories, measuredServices}
+	return &EtcdServiceRegistry{etcd, time.Duration(60) * time.Second, vulcandAddr, checker, services, categories, measuredServices}
 }
 
-func (r EtcdServiceRegistry) measuredServices() map[string]MeasuredService {
+func (r *EtcdServiceRegistry) measuredServices() map[string]MeasuredService {
 	return r._measuredServices
 }
 
-func (r EtcdServiceRegistry) checker() HealthChecker {
+func (r *EtcdServiceRegistry) checker() HealthChecker {
 	return r._checker
 }
 
-func (r EtcdServiceRegistry) categories() map[string]Category {
+func (r *EtcdServiceRegistry) categories() map[string]Category {
 	return r._categories
 }
 
-func (r EtcdServiceRegistry) watchServices() {
+func (r *EtcdServiceRegistry) watchServices() {
 	watcher := r.etcd.Watcher(servicesKeyPre, &client.WatcherOptions{AfterIndex: 0, Recursive: true})
 	limiter := NewEventLimiter(func() {
 		r.redefineServiceList()
 		r.updateMeasuredServiceList()
-	})
+	}, r.etcdInterval)
 	for {
 		_, err := watcher.Next(context.Background())
 		if err != nil {
@@ -127,7 +128,7 @@ func (r EtcdServiceRegistry) watchServices() {
 	}
 }
 
-func (r EtcdServiceRegistry) updateMeasuredServiceList() {
+func (r *EtcdServiceRegistry) updateMeasuredServiceList() {
 	// adding new services, not touching existing
 	for key := range r.services {
 		service := r.services[key]
@@ -150,11 +151,11 @@ func (r EtcdServiceRegistry) updateMeasuredServiceList() {
 	}
 }
 
-func (r EtcdServiceRegistry) watchCategories() {
+func (r *EtcdServiceRegistry) watchCategories() {
 	watcher := r.etcd.Watcher(categoriesKeyPre, &client.WatcherOptions{AfterIndex: 0, Recursive: true})
 	limiter := NewEventLimiter(func() {
 		r.redefineCategoryList()
-	})
+	}, r.etcdInterval)
 	for {
 		_, err := watcher.Next(context.Background())
 		if err != nil {
@@ -234,7 +235,7 @@ func (r *EtcdServiceRegistry) redefineCategoryList() {
 	infoLogger.Printf("%v", r._categories)
 }
 
-func (r EtcdServiceRegistry) catPeriod(catKey string) (period time.Duration) {
+func (r *EtcdServiceRegistry) catPeriod(catKey string) (period time.Duration) {
 	period = defaultDuration
 	periodResp, err := r.etcd.Get(context.Background(), catKey+periodKeySuffix, &client.GetOptions{Sort: true})
 	if err != nil {
@@ -250,7 +251,7 @@ func (r EtcdServiceRegistry) catPeriod(catKey string) (period time.Duration) {
 	return
 }
 
-func (r EtcdServiceRegistry) catResilient(catKey string) (resilient bool) {
+func (r *EtcdServiceRegistry) catResilient(catKey string) (resilient bool) {
 	resilient = false
 	resilientResp, err := r.etcd.Get(context.Background(), catKey+resilientSuffix, nil)
 	if err != nil {
@@ -264,7 +265,7 @@ func (r EtcdServiceRegistry) catResilient(catKey string) (resilient bool) {
 	return
 }
 
-func (r EtcdServiceRegistry) disableCategoryIfSticky(cat string) {
+func (r *EtcdServiceRegistry) disableCategoryIfSticky(cat string) {
 	sticky := false
 	stickyResp, err := r.etcd.Get(context.Background(), categoriesKeyPre+"/"+cat+stickySuffix, nil)
 	if err != nil {
@@ -285,7 +286,7 @@ func (r EtcdServiceRegistry) disableCategoryIfSticky(cat string) {
 	}
 }
 
-func (r EtcdServiceRegistry) catEnabled(catKey string) (enabled bool) {
+func (r *EtcdServiceRegistry) catEnabled(catKey string) (enabled bool) {
 	enabled = true
 	enabledResp, err := r.etcd.Get(context.Background(), catKey+enabledSuffix, nil)
 	if err != nil {
@@ -299,7 +300,7 @@ func (r EtcdServiceRegistry) catEnabled(catKey string) (enabled bool) {
 	return
 }
 
-func (r EtcdServiceRegistry) getAck(serviceKey string) string {
+func (r *EtcdServiceRegistry) getAck(serviceKey string) string {
 
 	ackDetails, err := r.etcd.Get(context.Background(), serviceKey+ackSuffix, nil)
 	if err != nil {
@@ -308,7 +309,7 @@ func (r EtcdServiceRegistry) getAck(serviceKey string) string {
 	return ackDetails.Node.Value
 }
 
-func (r EtcdServiceRegistry) scheduleCheck(mService *MeasuredService, timer *time.Timer) {
+func (r *EtcdServiceRegistry) scheduleCheck(mService *MeasuredService, timer *time.Timer) {
 	// wait
 	select {
 	case <-mService.cachedHealth.terminate:
@@ -330,7 +331,7 @@ func (r EtcdServiceRegistry) scheduleCheck(mService *MeasuredService, timer *tim
 	go r.scheduleCheck(mService, time.NewTimer(waitDuration))
 }
 
-func (r EtcdServiceRegistry) updateCachedAndBufferedHealth(mService *MeasuredService, healthResult *fthealth.HealthResult) {
+func (r *EtcdServiceRegistry) updateCachedAndBufferedHealth(mService *MeasuredService, healthResult *fthealth.HealthResult) {
 	// write to cache
 	mService.cachedHealth.toWriteToCache <- *healthResult
 
@@ -341,7 +342,7 @@ func (r EtcdServiceRegistry) updateCachedAndBufferedHealth(mService *MeasuredSer
 	}
 }
 
-func (r EtcdServiceRegistry) findShortestPeriod(service Service) time.Duration {
+func (r *EtcdServiceRegistry) findShortestPeriod(service Service) time.Duration {
 	minDuration := defaultDuration
 	for _, categoryName := range service.Categories {
 		category, ok := r._categories[categoryName]
@@ -356,7 +357,7 @@ func (r EtcdServiceRegistry) findShortestPeriod(service Service) time.Duration {
 }
 
 //returns true, only if all categoryNames are considered resilient.
-func (r EtcdServiceRegistry) areResilient(categoryNames []string) bool {
+func (r *EtcdServiceRegistry) areResilient(categoryNames []string) bool {
 	for _, c := range categoryNames {
 		if !r._categories[c].IsResilient {
 			return false
@@ -365,7 +366,7 @@ func (r EtcdServiceRegistry) areResilient(categoryNames []string) bool {
 	return true
 }
 
-func (r EtcdServiceRegistry) matchingCategories(s []string) []string {
+func (r *EtcdServiceRegistry) matchingCategories(s []string) []string {
 	var result []string
 	for _, a := range s {
 		if _, ok := r._categories[a]; ok {

--- a/serviceRegistry_test.go
+++ b/serviceRegistry_test.go
@@ -89,9 +89,10 @@ func TestWatchCategories(t *testing.T) {
 	registry.etcdInterval = time.Second
 
 	go registry.watchCategories()
-	time.Sleep(time.Duration(2) * time.Second)
+	time.Sleep(2 * time.Second)
 
 	actual := registry.categories()
+
 	assert.Len(t, actual, 2, "category list")
 	_, categoryPresent := actual["default"]
 	assert.True(t, categoryPresent, "default category should be present")


### PR DESCRIPTION
It's the original that needs to watch etcd, not a copy.
Make the eventlimiter interval configurable so that it can poll quickly
in testing.