### PR TITLE
Add cluster level ack

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Both the above are FT Standard compliant
 You can use both parameters in your query both on the good-to-go and healthcheck and endpoints even with `application/json` Accept header on the latter; e.g. `/__gtg?categories=read&cache=false`
 
 ### Ack support:
-
+#### Service level ack
 Currently if you want to acknowledge a service, you have to manually create an etcd key within the cluster. The etcd key would look like this:
 
 `etcdctl get /ft/healthcheck/foo-service-1/ack`
@@ -34,6 +34,26 @@ The etcd key have to be set in the following way:
 `etcdctl set /ft/healthcheck/foo-service-1/ack 'Details of the ack - who acked the service, why, etc.'`
 
 The ACK that is not needed anymore should be removed also manually from etcd: `etcdctl rm /ft/healthcheck/foo-service-1/ack`
+
+#### Cluster level ack
+The cluster can be acked as a whole.
+
+Consequences of acking the whole cluster:
+- When a cluster is acked, it will appear its dashing tile will be green
+- The UI will have a text message in the heading: (Cluster is acked: ACK-MESSAGE)
+- In the JSON response of agg-hc __health endpoint the main ok field will be true, event though some services might be unhealthy
+
+Note:
+ - The gtg endpoint will have the same functionality as before (it will continue to respond with 503 if it is the case, even though the cluster is acknowledged) to ensure a proper work of failovers
+
+
+To ack the cluster, add the following etcd entry:
+
+`etcdctl set /ft/config/aggregate-healthcheck/cluster-ack <ACK-MESSAGE>`
+
+To remove the ack, remove the etcd entry that holds the ack message:
+
+`etcdctl rm /ft/config/aggregate-healthcheck/cluster-ack`
 
 ### Categories:
 

--- a/controller_test.go
+++ b/controller_test.go
@@ -42,7 +42,7 @@ func (r MockRegistry) checker() HealthChecker {
 	return args.Get(0).(HealthChecker)
 }
 
-func (r MockRegistry) getAck(serviceKey string) string {
+func (r MockRegistry) getServiceAck(serviceKey string) string {
 	args := r.Called(serviceKey)
 	return args.String(0)
 }
@@ -53,6 +53,10 @@ func (r MockRegistry) disableCategoryIfSticky(category string) {
 
 func (r MockRegistry) updateCachedAndBufferedHealth(service *MeasuredService, result *fthealth.HealthResult) {
 	r.Called(service, result)
+}
+
+func (r MockRegistry) clusterAck() string {
+	return ""
 }
 
 type MockHealthChecker struct {
@@ -107,7 +111,7 @@ func mockServices(r *MockRegistry, healthyServicesAndCategories map[string][]str
 	}
 
 	r.On("measuredServices").Return(measuredServices)
-	r.On("getAck", mock.MatchedBy(any)).Return("")
+	r.On("getServiceAck", mock.MatchedBy(any)).Return("")
 	r.On("updateCachedAndBufferedHealth", mock.MatchedBy(any), mock.MatchedBy(any)).Return()
 }
 

--- a/main.go
+++ b/main.go
@@ -94,8 +94,6 @@ func main() {
 		}
 		etcdKeysAPI := etcdClient.NewKeysAPI(etcd)
 
-
-
 		registry := NewCocoServiceRegistry(etcdKeysAPI, *vulcandAddr, checker)
 		registry.redefineCategoryList()
 		registry.redefineServiceList()
@@ -103,6 +101,7 @@ func main() {
 
 		go registry.watchServices()
 		go registry.watchCategories()
+		go registry.watchClusterAck()
 
 		graphiteFeeder := NewGraphiteFeeder(*graphiteHost, *graphitePort, *environment, registry)
 		go graphiteFeeder.feed()

--- a/main.html
+++ b/main.html
@@ -10,7 +10,8 @@
     {{else}}<span style='color: orange;'>unhealthy</span>
     {{end}}
     {{end}}
-    {{if .Ack.IsAcked}} <span style='color: blue;'>({{.Ack.Count}} services acked)</span>
+    {{if .ServicesAck.IsAcked}} <span style='color: blue;'>({{.ServicesAck.Count}} services acked)</span>
+    {{if .ClusterAck}} <span style='color: blue;'>(Cluster is acked: {{.ClusterAck}})</span>
     {{end}}
 </h1>
 <table style='font-size: 10pt; font-family: MONOSPACE;'>

--- a/main.html
+++ b/main.html
@@ -11,6 +11,7 @@
     {{end}}
     {{end}}
     {{if .ServicesAck.IsAcked}} <span style='color: blue;'>({{.ServicesAck.Count}} services acked)</span>
+    {{end}}
     {{if .ClusterAck}} <span style='color: blue;'>(Cluster is acked: {{.ClusterAck}})</span>
     {{end}}
 </h1>

--- a/serviceRegistry.go
+++ b/serviceRegistry.go
@@ -17,6 +17,7 @@ import (
 
 const (
 	servicesKeyPre      = "/ft/healthcheck"
+	clusterAckEtcdKey   = "/ft/config/aggregate-healthcheck/cluster-ack"
 	categoriesKeyPre    = "/ft/healthcheck-categories"
 	periodKeySuffix     = "/period_seconds"
 	resilientSuffix     = "/is_resilient"
@@ -71,9 +72,10 @@ type ServiceRegistry interface {
 	areResilient([]string) bool
 	measuredServices() map[string]MeasuredService
 	checker() HealthChecker
-	getAck(string) string
+	getServiceAck(string) string
 	disableCategoryIfSticky(string)
 	categories() map[string]Category
+	clusterAck() string
 	updateCachedAndBufferedHealth(*MeasuredService, *fthealth.HealthResult)
 }
 
@@ -86,6 +88,7 @@ type EtcdServiceRegistry struct {
 	services          servicesMap
 	_categories       categoriesMap
 	_measuredServices map[string]MeasuredService
+	_clusterAck       string
 }
 
 type EtcdHealthCheckKeysAPI interface {
@@ -98,7 +101,7 @@ func NewCocoServiceRegistry(etcd EtcdHealthCheckKeysAPI, vulcandAddr string, che
 	services := make(map[string]Service)
 	categories := make(map[string]Category)
 	measuredServices := make(map[string]MeasuredService)
-	return &EtcdServiceRegistry{sync.Mutex{}, etcd, time.Duration(60) * time.Second, vulcandAddr, checker, services, categories, measuredServices}
+	return &EtcdServiceRegistry{sync.Mutex{}, etcd, time.Duration(60) * time.Second, vulcandAddr, checker, services, categories, measuredServices, ""}
 }
 
 func (r *EtcdServiceRegistry) measuredServices() map[string]MeasuredService {
@@ -114,6 +117,43 @@ func (r *EtcdServiceRegistry) categories() map[string]Category {
 	defer r.Unlock()
 
 	return r._categories
+}
+
+func (r *EtcdServiceRegistry) clusterAck() string {
+	r.Lock()
+	defer r.Unlock()
+
+	return r._clusterAck
+}
+
+func (r *EtcdServiceRegistry) watchClusterAck() {
+	watcher := r.etcd.Watcher(clusterAckEtcdKey, &client.WatcherOptions{AfterIndex: 0, Recursive: true})
+	limiter := NewEventLimiter(func() {
+		r.redefineClusterAck()
+	}, r.etcdInterval)
+	for {
+		_, err := watcher.Next(context.Background())
+		if err != nil {
+			errorLogger.Printf("Error waiting for change under %v in etcd. %v\n Sleeping 10s...", clusterAckEtcdKey, err.Error())
+			time.Sleep(10 * time.Second)
+			continue
+		}
+		limiter.trigger <- true
+	}
+}
+
+func (r *EtcdServiceRegistry) redefineClusterAck() {
+	infoLogger.Print("Reloading cluster ack")
+	clusterAckResp, err := r.etcd.Get(context.Background(), clusterAckEtcdKey, &client.GetOptions{Sort: true})
+	if err != nil {
+		errorLogger.Printf("Failed to get value from %v: %v.", clusterAckEtcdKey, err.Error())
+		return
+	}
+
+	r.Lock()
+	defer r.Unlock()
+
+	r._clusterAck = clusterAckResp.Node.Value
 }
 
 func (r *EtcdServiceRegistry) watchServices() {
@@ -204,7 +244,7 @@ func (r *EtcdServiceRegistry) redefineServiceList() {
 		if err == nil {
 			categories = append(categories, strings.Split(categoriesResp.Node.Value, ",")...)
 		}
-		ack := r.getAck(serviceNode.Key)
+		ack := r.getServiceAck(serviceNode.Key)
 		services[name] = Service{Name: name, Host: r.vulcandAddr, Path: fmt.Sprintf(pathPre, name, path), Categories: categories, Ack: ack, ServiceKey: serviceNode.Key}
 	}
 	r.services = services
@@ -309,7 +349,7 @@ func (r *EtcdServiceRegistry) catEnabled(catKey string) (enabled bool) {
 	return
 }
 
-func (r *EtcdServiceRegistry) getAck(serviceKey string) string {
+func (r *EtcdServiceRegistry) getServiceAck(serviceKey string) string {
 
 	ackDetails, err := r.etcd.Get(context.Background(), serviceKey+ackSuffix, nil)
 	if err != nil {

--- a/serviceRegistry.go
+++ b/serviceRegistry.go
@@ -150,7 +150,7 @@ func (r *EtcdServiceRegistry) redefineClusterAck() {
 	defer r.Unlock()
 	if err != nil {
 		r._clusterAck = ""
-		errorLogger.Printf("Failed to get value from %v: %v.", clusterAckEtcdKey, err.Error())
+		errorLogger.Printf("Failed to get value from %v: %v. Removing cluster ack message.", clusterAckEtcdKey, err.Error())
 		return
 	}
 

--- a/serviceRegistry.go
+++ b/serviceRegistry.go
@@ -145,13 +145,14 @@ func (r *EtcdServiceRegistry) watchClusterAck() {
 func (r *EtcdServiceRegistry) redefineClusterAck() {
 	infoLogger.Print("Reloading cluster ack")
 	clusterAckResp, err := r.etcd.Get(context.Background(), clusterAckEtcdKey, &client.GetOptions{Sort: true})
-	if err != nil {
-		errorLogger.Printf("Failed to get value from %v: %v.", clusterAckEtcdKey, err.Error())
-		return
-	}
 
 	r.Lock()
 	defer r.Unlock()
+	if err != nil {
+		r._clusterAck = ""
+		errorLogger.Printf("Failed to get value from %v: %v.", clusterAckEtcdKey, err.Error())
+		return
+	}
 
 	r._clusterAck = clusterAckResp.Node.Value
 }


### PR DESCRIPTION
With this new functionality, we will be able to acknowledge a cluster as a whole. 
Consequences:
 - When a cluster is acked, it will appear its dashing tile will be green
 - The UI will have a text message in the heading: (Cluster is acked: ACK-MESSAGE)
 - In the JSON response of  agg-hc `__health` endpoint the main `ok`  field will be true, event though some services might be unhealthy

Note:
 - The gtg endpoint will have the same functionality as before (it will continue to respond with 503 if it is the case, even though the cluster is acknowledged) to ensure a proper work of failovers