### PR TITLE
Add aggregate healthcheck endpoint

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -231,6 +231,53 @@ func (c Controller) handleHealthcheck(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+/** 
+ * Surfaces an endpoint which returns checks from all services in the cluster
+ *
+ * Note: doesn't currently avail of caching, so may be a little slow.
+ */
+func (c Controller) handleAggHealthcheck(w http.ResponseWriter, r *http.Request) {
+
+	var response struct {
+		SchemaVersion         float64 `json:"schemaVersion"`
+		AggregationSystemCode string  `json:"aggregationSystemCode,omitempty"`
+		Checks                []check `json:"checks"`
+	}
+
+	// Hardcode the System Code of the system doing the aggregation
+	response.AggregationSystemCode = "aggregate-healthcheck"
+	response.SchemaVersion = 1
+
+	// Fetch each service's checks and annotate them with the service's system code
+	for _, mService := range c.registry.measuredServices() {
+		serviceHealthcheck, _ := c.registry.checker().FetchHealthcheck(*mService.service)
+		for _, check := range serviceHealthcheck.Checks {
+			check.CheckSystemCode = serviceHealthcheck.SystemCode
+
+			// Ideally all healthchecks would specify a system code, but for legacy reasons fallback to using the service name
+			if (serviceHealthcheck.SystemCode == "") {
+				check.CheckSystemCode = mService.service.Name
+			}
+
+			// Similarly for the check ID, fallback to name
+			if (check.ID == "") {
+				check.ID = check.Name
+			}
+			response.Checks = append(response.Checks, check)
+		}
+	}
+
+	// Return as JSON regardless of accept header
+	w.Header().Set("Content-Type", "application/json")
+
+	enc := json.NewEncoder(w)
+
+	err := enc.Encode(response)
+	if err != nil {
+		panic("Couldn't encode aggregate health results to ResponseWriter.")
+	}
+}
+
 func (c Controller) handleGoodToGo(w http.ResponseWriter, r *http.Request) {
 	categories := parseCategories(r.URL)
 

--- a/controller_test.go
+++ b/controller_test.go
@@ -73,6 +73,11 @@ func (c *MockHealthChecker) IsHighSeverity(service string) bool {
 	return args.Bool(0)
 }
 
+func (c *MockHealthChecker) FetchHealthcheck(service Service) (*healthcheckResponse, error) {
+	health := &healthcheckResponse{}
+	return health, nil
+}
+
 func mockCategories(r *MockRegistry, enabled []string, disabled []string) {
 	categories := make(map[string]Category)
 	for _, cat := range enabled {

--- a/main.go
+++ b/main.go
@@ -111,10 +111,12 @@ func main() {
 
 		handler := controller.handleHealthcheck
 		gtgHandler := controller.handleGoodToGo
+		aggHandler := controller.handleAggHealthcheck
 		r := mux.NewRouter()
 		r.HandleFunc("/", handler)
 		r.HandleFunc("/__health", handler)
 		r.HandleFunc("/__gtg", gtgHandler)
+		r.HandleFunc("/__agghealth", aggHandler)
 		err = http.ListenAndServe(":8080", r)
 		if err != nil {
 			errorLogger.Println("Can't set up HTTP listener on 8080.")


### PR DESCRIPTION
Adds a /__agghealth endpoint as per this draft standard: https://docs.google.com/document/d/1vaFUzx7LV0a9oEOZJ4VHW6-D1m10GG9qEVub00VElMo/edit

This gives us the option to retrieve all check data from the aggregator in a single request.